### PR TITLE
Improved 'pilot_label_processing' with Time-Based Labeling Support

### DIFF
--- a/crossai/performance/_utils.py
+++ b/crossai/performance/_utils.py
@@ -4,7 +4,8 @@ import numpy as np
 
 def pilot_label_processing(json_path: str,
                            classes: list = None,
-                           n_instances: int = None):
+                           n_instances: int = None,
+                           sampling_rate: int = 16000):
     """Processes the labels of pilot data to be compared to the model's output.
 
         The labels must be in a json array looking like this:
@@ -28,6 +29,28 @@ def pilot_label_processing(json_path: str,
                 "end": 350
             },
         ]
+        or like this if type = 'time', where the start and end values are
+        given in seconds:
+        [
+            {
+                "label": "sneeze",
+                "type": "time",
+                "start": 0.118,
+                "end": 0.122
+            },
+            {
+                "label": "sneeze",
+                "type": "time",
+                "start": 0.168,
+                "end": 0.194
+            },
+            {
+                "label": "cough",
+                "type": "time",
+                "start": 0.312,
+                "end": 0.350
+            },
+        ]
 
     Args:
         json_path (str): Path to the json file.
@@ -36,6 +59,8 @@ def pilot_label_processing(json_path: str,
             List has shape: ['sneeze', 'cough', ...]
         n_instances (int): Number of instances in the data. The number will
             determine the length of the label array.
+        sampling_rate (int): The sampling rate of the audio data.
+            Used if type = 'time'.
     Returns:
         labels (list): list of processed labels.
         segments(list): List of label segments ([start, end, label], [...]).
@@ -55,6 +80,10 @@ def pilot_label_processing(json_path: str,
     for label in data:
         # Get segments
         label["label"] = classes.index(label["label"])
+        if label['type'] == 'time':
+            label['start'] = int(label['start'] * sampling_rate)
+            label['end'] = int(label['end'] * sampling_rate)
+
         segments.append([label['start'], label['end'], label['label']])
         # map labels to label array
         for i in range(label['start'], label['end']):

--- a/crossai/performance/_utils.py
+++ b/crossai/performance/_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 def pilot_label_processing(json_path: str,
                            classes: list = None,
                            n_instances: int = None,
-                           sampling_rate: int = 16000):
+                           sampling_rate: int = None):
     """Processes the labels of pilot data to be compared to the model's output.
 
         The labels must be in a json array looking like this:
@@ -56,7 +56,8 @@ def pilot_label_processing(json_path: str,
         json_path (str): Path to the json file.
         classes (list): List of classes that map to the model output.
             The given list maps to numbers incrementally.
-            List has shape: ['sneeze', 'cough', ...]
+            List has shape: ['sneeze', 'cough', ...] and must contain all
+            classes that are in the json file.
         n_instances (int): Number of instances in the data. The number will
             determine the length of the label array.
         sampling_rate (int): The sampling rate of the audio data.
@@ -76,6 +77,9 @@ def pilot_label_processing(json_path: str,
         data = json.load(f)
     # create label array with None class
     labels = [np.nan] * n_instances
+    if data[0]['type'] == 'time':
+        if sampling_rate is None:
+            raise ValueError('sampling_rate must be defined when type = time.')
 
     for label in data:
         # Get segments

--- a/crossai/performance/_utils.py
+++ b/crossai/performance/_utils.py
@@ -72,7 +72,6 @@ def pilot_label_processing(json_path: str,
 
     segments = []
 
-    # load json
     with open(json_path) as f:
         data = json.load(f)
     # create label array with None class


### PR DESCRIPTION
This pull request refines the pilot_label_processing functionality by introducing support for the time type in the accepted JSON format. This enhancement proves particularly beneficial in scenarios where labeling is based on time intervals rather than individual samples, such as in audio processing where the sampling rate may not be fixed.

Noteworthy Points:

- The API for type = samples remains unchanged.
- In cases where the time type is specified without an accompanying sampling rate, an error is raised.